### PR TITLE
rhine: ril: Return static radio capability from getRadioCapability

### DIFF
--- a/PlatformConfig2.mk
+++ b/PlatformConfig2.mk
@@ -24,3 +24,6 @@ TARGET_KERNEL_SOURCE := kernel/sony/msm
 
 # Nfc
 TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS := true
+
+# RIL class override
+BOARD_RIL_CLASS := ../../../$(PLATFORM_COMMON_PATH)/ril/

--- a/ril/com/android/internal/telephony/SonyRIL.java
+++ b/ril/com/android/internal/telephony/SonyRIL.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.telephony;
+
+import static com.android.internal.telephony.RILConstants.*;
+
+import android.content.Context;
+import android.os.AsyncResult;
+import android.os.Message;
+
+public class SonyRIL extends RIL implements CommandsInterface {
+    public SonyRIL(Context context, int preferredNetworkType, int cdmaSubscription) {
+        super(context, preferredNetworkType, cdmaSubscription, null);
+    }
+
+    public SonyRIL(Context context, int preferredNetworkType,
+            int cdmaSubscription, Integer instanceId) {
+        super(context, preferredNetworkType, cdmaSubscription, instanceId);
+    }
+
+    @Override
+    public void getRadioCapability(Message response) {
+        riljLog("getRadioCapability: returning static radio capability");
+        if (response != null) {
+            Object ret = makeStaticRadioCapability();
+            AsyncResult.forMessage(response, ret, null);
+            response.sendToTarget();
+        }
+    }
+}

--- a/system.prop
+++ b/system.prop
@@ -13,3 +13,6 @@ cpuquiet.normal.max_cpus=4
 rqbalance.normal.balance_level=40
 rqbalance.normal.up_threshold=100 250 330 4294967295
 rqbalance.normal.down_threshold=0 130 220 300
+
+# RIL class override
+ro.telephony.ril_class=SonyRIL


### PR DESCRIPTION
Our modem doesn't return REQUEST_NOT_SUPPORTED but some wrong response. This leads to calling ProxyController with bad parameters and ProxyController doesn't release it's wakelock when error state.

Also this method requires modem capabilites declared because it can't get them from the modem. We already have them in sony common repo.